### PR TITLE
Updates widget titles without page refresh

### DIFF
--- a/views/default/widget_manager/js/site.php
+++ b/views/default/widget_manager/js/site.php
@@ -26,6 +26,44 @@ function widget_manager_init(){
 			$(".widget-manager-groups-widgets-top-row").removeClass("widget-manager-groups-widgets-top-row-highlight");
 		}
 	});
+	
+
+	// live update of widget titles
+    $('.elgg-form-widgets-save input.elgg-button-submit').live('click', function() {
+ 
+      var widgetId = $(this).siblings('input:hidden[name="guid"]').val();
+      var customTitle = $('#widget-manager-widget-edit-advanced-'+widgetId+' input:text[name="params[widget_manager_custom_title]"]').val();
+      var originalTitle = $('#elgg-widget-'+widgetId+' .elgg-widget-handle h3 a').text();
+      if (originalTitle.length == 0) {
+        originalTitle = $('#elgg-widget-'+widgetId+' .elgg-widget-handle h3').text();
+      }
+      
+      var customUrl = $('#widget-manager-widget-edit-advanced-'+widgetId+' input:text[name="params[widget_manager_custom_url]"]').val();
+      var originalUrl = $('#elgg-widget-'+widgetId+' .elgg-widget-handle h3 a').attr("href");
+	  
+	  // clean custom title, prevent scripting
+	  var cleanText = $('<div class="stripHTMLClass">text</div>');
+	  customTitle = cleanText.text(customTitle).html();
+      
+      if (customTitle.length == 0) {
+        customTitle = originalTitle;
+      }
+      
+      if (customUrl.length == 0) {
+        customUrl = originalUrl;
+      }
+      
+      // big long regex provided by the jquery validation plugin
+      // only create link if the url is valid
+      if(/^([a-z]([a-z]|\d|\+|-|\.)*):(\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?((\[(|(v[\da-f]{1,}\.(([a-z]|\d|-|\.|_|~)|[!\$&'\(\)\*\+,;=]|:)+))\])|((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=])*)(:\d*)?)(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*|(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)|((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)|((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)){0})(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i.test(customUrl)) {
+        var completeTitle = '<a href="'+customUrl+'">'+customTitle+'</a>';
+      } else {
+        var completeTitle = customTitle;
+      }
+      
+      $('#elgg-widget-'+widgetId+' .elgg-widget-handle h3').html(completeTitle);
+    });
+
 }
 
 elgg.register_hook_handler('init', 'system', widget_manager_init);


### PR DESCRIPTION
Currently when you change the widget title you don't see the result until the next page refresh.  This makes the change take place immediately, feels a bit more responsive in line with the rest of the widgets behaviour
