### PR TITLE
Fixes

### DIFF
--- a/classes/MultiDashboard.php
+++ b/classes/MultiDashboard.php
@@ -27,20 +27,6 @@ class MultiDashboard extends ElggObject {
 	}
 	
 	/**
-	 * Returns url to the dashboard
-	 *
-	 * @return string|boolean
-	 */
-	public function getURL() {
-		if (empty($this->guid)) {
-			return false;
-		}
-
-		$site = elgg_get_site_entity($this->site_guid);
-		return $site->url . 'dashboard/' . $this->getGUID();
-	}
-	
-	/**
 	 * On delete of dashboard remove all widgets in it
 	 *
 	 * @param boolean $recursive Whether to delete all the entities contained by this entity

--- a/classes/MultiDashboard.php
+++ b/classes/MultiDashboard.php
@@ -27,21 +27,6 @@ class MultiDashboard extends ElggObject {
 	}
 	
 	/**
-	 * Correctly sets attributes on save
-	 *
-	 * @return void
-	 */
-	public function save() {
-		if (!$this->guid) {
-			$this->attributes['owner_guid'] = elgg_get_logged_in_user_guid();
-			$this->attributes['container_guid'] = elgg_get_logged_in_user_guid();
-			$this->attributes['access_id'] = ACCESS_PRIVATE;
-		}
-		
-		return parent::save();
-	}
-	
-	/**
 	 * Returns url to the dashboard
 	 *
 	 * @return string|boolean

--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -396,7 +396,24 @@ function widget_manager_widgets_url($hook_name, $entity_type, $return_value, $pa
 
 	return $result;
 }
-	
+
+/**
+ * Sets default dashboard entity URL
+ * 
+ * @param string $hook   "entity:url"
+ * @param string $type   "object"
+ * @param string $return URL
+ * @param array  $params Hook params
+ * @return string
+ */
+function widget_manager_dashboard_url($hook, $type, $return, $params) {
+	$entity = elgg_extract('entity', $params);
+	if (!$entity instanceof MultiDashboard) {
+		return;
+	}
+	return elgg_normalize_url("dashboard/$entity->guid");
+}
+
 /**
  * Allow for group default widgets
  *

--- a/start.php
+++ b/start.php
@@ -84,6 +84,8 @@ function widget_manager_init() {
 	elgg_register_plugin_hook_handler('entity:url', 'object', 'widget_manager_widgets_url');
 	// widget manager widgets
 	elgg_register_plugin_hook_handler('entity:url', 'object', 'widget_manager_widgets_url_hook_handler');
+	// dashboard
+	elgg_register_plugin_hook_handler('entity:url', 'object', 'widget_manager_dashboard_url');
 
 	// cacheable widget handlers
 	elgg_register_plugin_hook_handler('cacheable_handlers', 'widget_manager', 'widget_manager_cacheable_handlers_hook_handler');

--- a/views/default/widget_manager/multi_dashboard/navigation.php
+++ b/views/default/widget_manager/multi_dashboard/navigation.php
@@ -40,12 +40,17 @@ if (!empty($md_entities)) {
 		}
 		
 		$order = $entity->order ? $entity->order : $entity->time_created;
-		
-		$tabs[$order] = [
-			'text' => $tab_title . elgg_view_icon('settings-alt', [
+
+		$edit_icon = '';
+		if ($entity->canEdit()) {
+			$edit_icon = elgg_view_icon('settings-alt', [
 				'class' => 'widget-manager-multi-dashboard-tabs-edit hidden',
 				'data-multi-dashboard-edit-link' => elgg_normalize_url("ajax/view/widget_manager/forms/multi_dashboard?guid={$entity->getGUID()}"),
-			]),
+			]);
+		}
+		
+		$tabs[$order] = [
+			'text' => $tab_title . $edit_icon,
 			'href' => $entity->getURL(),
 			'title' => $entity->title,
 			'selected' => $selected,


### PR DESCRIPTION
**fix(classes): MultiDashboard::save() no longer sets attributes**
`MultiDashboard::save()` was duplicating logic done in `ElggObject` and `ElggEntity`, additionally creating problems when dashboards were created programmatically.
Fixes #78

**feature(url): dashboard entity URLs can now be filtered**
Dashboard URL can now be filtered by core `entity:url` hook.
Fixes #83

**fix(ui): only show edit icon if dashboard is editable**
Fixes #80